### PR TITLE
bug fix: pass the rkey of the mr to the client for rdma read/write operations instead of the lkey

### DIFF
--- a/src/rdma_server.c
+++ b/src/rdma_server.c
@@ -314,7 +314,7 @@ static int send_server_metadata_to_client()
 	*/
        server_metadata_attr.address = (uint64_t) server_buffer_mr->addr;
        server_metadata_attr.length = (uint32_t) server_buffer_mr->length;
-       server_metadata_attr.stag.local_stag = (uint32_t) server_buffer_mr->lkey;
+       server_metadata_attr.stag.remote_stag = (uint32_t) server_buffer_mr->rkey;
        server_metadata_mr = rdma_buffer_register(pd /* which protection domain*/, 
 		       &server_metadata_attr /* which memory to register */, 
 		       sizeof(server_metadata_attr) /* what is the size of memory */,


### PR DESCRIPTION
In 'man ibv_reg_mr': 

RETURN VALUE
       ibv_reg_mr() / ibv_reg_mr_iova() / ibv_reg_dmabuf_mr() returns a pointer to the registered MR, or NULL if  the  request
       fails.   The  local  key  (L_Key)  field  lkey  is  used  as the lkey field of struct ibv_sge when posting buffers with
       ibv_post_* verbs, and the the remote key (R_Key) field rkey is used by remote processes to perform Atomic and RDMA operations. The  remote  process  places  this rkey as the rkey field of struct ibv_send_wr passed to the ibv_post_send
       function.

So the rkey of mr should be passed to client for rdma operations.

The most interesting thing is that in most of implementaions, rkey and lkey of one mr is exactly the same. So the previous code usually runs correctly.